### PR TITLE
Update  icon  to support older versions of Unity

### DIFF
--- a/Editor/RecentSceneToolbarGUI.cs
+++ b/Editor/RecentSceneToolbarGUI.cs
@@ -42,7 +42,7 @@ namespace RecentSceneToolbar {
 			}
 			
 			
-			var plusButtonTex = EditorGUIUtility.IconContent(@"d_ol_plus_act").image;
+			var plusButtonTex = EditorGUIUtility.IconContent(@"Toolbar Plus").image;
 			if (GUILayout.Button(new GUIContent(null, plusButtonTex, $"Additively load recent scenes"), style)) {
 				PopupRecentScene(
 					(sceneIndex) => {

--- a/Editor/RecentSceneToolbarGUI.cs
+++ b/Editor/RecentSceneToolbarGUI.cs
@@ -40,9 +40,12 @@ namespace RecentSceneToolbar {
 						RecentSceneList.Instance.LoadScene(sceneIndex);
 					});
 			}
-			
-			
+
+#if UNITY_2019_1_OR_NEWER
+			var plusButtonTex = EditorGUIUtility.IconContent(@"d_ol_plus_act").image;
+#else
 			var plusButtonTex = EditorGUIUtility.IconContent(@"Toolbar Plus").image;
+#endif
 			if (GUILayout.Button(new GUIContent(null, plusButtonTex, $"Additively load recent scenes"), style)) {
 				PopupRecentScene(
 					(sceneIndex) => {


### PR DESCRIPTION
"d_ol_plus_act" is not available in older versions of Unity
```
Unable to load the icon: 'd_ol_plus_act'.
Note that either full project path should be used (with extension) or just the icon name if the icon is located in the following location: 'Assets/Editor Default Resources/Icons/' (without extension, since png is assumed)
UnityEditor.EditorGUIUtility:IconContent(String)
RecentSceneToolbar.RecentSceneToolbarGUI:OnToolbarGUI() (at E:/Github/Unity-Recent-Scene-Toolbar/Editor/RecentSceneToolbarGUI.cs:45)
UnityToolbarExtender.ToolbarExtender:OnGUI() (at E:/Github/Unity-Recent-Scene-Toolbar/unity-toolbar-extender-1.4.3/Editor/ToolbarExtender.cs:143)
UnityToolbarExtender.ToolbarCallback:OnGUI() (at E:/Github/Unity-Recent-Scene-Toolbar/unity-toolbar-extender-1.4.3/Editor/ToolbarCallback.cs:108)
UnityEngine.GUIUtility:ProcessEvent(Int32, IntPtr) (at C:/buildslave/unity/build/Modules/IMGUI/GUIUtility.cs:179)
```

I replaced it with "Toolbar Plus" from [Unity-2018.1.6](https://github.com/halak/unity-editor-icons/tree/364f85623beb3124de277a8ff3a1d88a2bea0349)
![image](https://github.com/qwe321qwe321qwe321/Unity-Recent-Scene-Toolbar/assets/2897430/d2817c7c-1a06-4e48-a43f-25e0d3a51295)
