### PR TITLE
Change the plus icon `d_ol_plus_act` check to UNITY_2019_4_OR_NEWER.

### DIFF
--- a/Editor/RecentSceneToolbarGUI.cs
+++ b/Editor/RecentSceneToolbarGUI.cs
@@ -41,7 +41,7 @@ namespace RecentSceneToolbar {
 					});
 			}
 
-#if UNITY_2019_1_OR_NEWER
+#if UNITY_2019_4_OR_NEWER
 			var plusButtonTex = EditorGUIUtility.IconContent(@"d_ol_plus_act").image;
 #else
 			var plusButtonTex = EditorGUIUtility.IconContent(@"Toolbar Plus").image;


### PR DESCRIPTION
See https://github.com/qwe321qwe321qwe321/Unity-Recent-Scene-Toolbar/pull/1#discussion_r1532744630